### PR TITLE
Defect/handedness

### DIFF
--- a/src/components/NewPlayerForm.jsx
+++ b/src/components/NewPlayerForm.jsx
@@ -124,7 +124,7 @@ NewPlayerForm.propTypes = {
   first_name: PropTypes.string,
   last_name: PropTypes.string,
   rating: PropTypes.number,
-  handedness: PropTypes.string,
+  handedness: PropTypes.string.isRequired,
   submit: PropTypes.func.isRequired,
   change: PropTypes.func.isRequired,
 };
@@ -133,7 +133,6 @@ NewPlayerForm.defaultProps = {
   first_name: 'Eddie',
   last_name: 'Van Halen',
   rating: 11,
-  handedness: 'right',
 };
 
 export default NewPlayerForm;

--- a/src/components/NewPlayerForm.jsx
+++ b/src/components/NewPlayerForm.jsx
@@ -133,7 +133,7 @@ NewPlayerForm.defaultProps = {
   first_name: 'Eddie',
   last_name: 'Van Halen',
   rating: 11,
-  handedness: 'left',
+  handedness: 'right',
 };
 
 export default NewPlayerForm;

--- a/src/components/SelectGroup.jsx
+++ b/src/components/SelectGroup.jsx
@@ -82,7 +82,7 @@ SelectGroup.propTypes = {
   })),
   id: PropTypes.string,
   label: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.string.isRequired,
   name: PropTypes.string,
   change: PropTypes.func.isRequired,
 };
@@ -91,7 +91,6 @@ SelectGroup.defaultProps = {
   data: [{ id: 1, title: 'Title', value: 'value' }],
   id: 'defaultSelect',
   label: 'Default Select',
-  value: 'value',
   name: 'default_select',
 };
 

--- a/src/components/SelectGroup.jsx
+++ b/src/components/SelectGroup.jsx
@@ -61,7 +61,12 @@ const SelectGroup = (props) => {
     <Field>
       <label htmlFor={props.id}>
         {props.label}
-        <select name={props.name} id={props.id}>
+        <select
+          name={props.name}
+          id={props.id}
+          value={props.value}
+          onChange={props.change}
+        >
           {options}
         </select>
       </label>
@@ -77,13 +82,16 @@ SelectGroup.propTypes = {
   })),
   id: PropTypes.string,
   label: PropTypes.string,
+  value: PropTypes.string,
   name: PropTypes.string,
+  change: PropTypes.func.isRequired,
 };
 
 SelectGroup.defaultProps = {
   data: [{ id: 1, title: 'Title', value: 'value' }],
   id: 'defaultSelect',
   label: 'Default Select',
+  value: 'value',
   name: 'default_select',
 };
 

--- a/src/pages/NewPlayer.jsx
+++ b/src/pages/NewPlayer.jsx
@@ -13,7 +13,7 @@ export default class NewPlayer extends Component {
       first_name: '',
       last_name: '',
       rating: '',
-      handedness: 'right',
+      handedness: '',
       toRoster: false,
       errorMessage: '',
       hasError: false,


### PR DESCRIPTION
Select component was missing `value` and `onChange` props allowing change of state to bubble up to parent `NewPlayer` page. 

Updating the `PropTypes` to `isRequired` allows for user to see change when different options are selected, i.e., when a default prop of 'right' is declared, if a user selects any other option it still shows 'right' in the select but /roster reflects correct data.

**Testing**
- Visit /roster to see list of players
- Click button at the bottom to add a competitor
- Fill in all fields and add a left and right-handed player to roster
- New player form should redirect to /roster showing data entered at the bottom of the list